### PR TITLE
:sparkles: renovate config

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,4 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": ["github>app-sre/shared-pipelines//renovate/default.json"]
+}


### PR DESCRIPTION
Enable our standard renovate config to keep track of all Python dependencies.